### PR TITLE
Cprados patch history url

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -181,6 +181,6 @@ For mere information kan du gå til <b>Info</b> i program menuen.</string>
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">Se et eksempel</string>
     <string name="preference_history_example_summary">Se hvordan fanen Historik ville se ud</string>   
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
     
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -181,6 +181,6 @@ Für weitere Infos gehen Sie zu <b>Info</b> im Applikations-Menu.</string>
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">Beispiel ansehen</string>
     <string name="preference_history_example_summary">Schauen Sie sich ein Beispiel den Verlauf an</string>   
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
     
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -181,6 +181,6 @@ Para más información puedes ir a <b>Ayuda</b> desde el menú de la aplicación
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>            
     <string name="preference_history_example_title">Ver un ejemplo</string>
     <string name="preference_history_example_summary">Ver cómo quedaría el tab de Historial</string>   
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
     
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -181,6 +181,6 @@ Pour plus d’information vous pouvez aller sur <b>Info</b> depuis le menu de l�
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">Voir un exemple</string>
     <string name="preference_history_example_summary">Voir un exemple de l’historique</string>   
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
     
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -181,6 +181,6 @@ További információkért válassza az alkalmazás menüjéből az <b>Infó</b>
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">Lásd egy példa</string>
     <string name="preference_history_example_summary">Nézze meg, hogyan az Előzmények fülre nézne</string>   
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
     
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -181,6 +181,6 @@ Per maggiori informazioni puoi andare su <b>Info</b> dal menu dell\'applicazione
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">Vedere un esempio</string>
     <string name="preference_history_example_summary">Vedere come la scheda Cronologia sarà simile</string>   
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
            
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -177,6 +177,6 @@ Wi-Fi Maticはあなたのいる場所に応じて自動的にデバイスのWi-
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">例を見る</string>
     <string name="preference_history_example_summary">履歴機能がどのようなものか見る</string>
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string>
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string>
 
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -181,6 +181,6 @@ Voor informatie ga naar het <b>Info</b> aplicatie menu.</string>
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">Voorbeeld tonen</string>
     <string name="preference_history_example_summary">Kijk hoe de geschiedenis tab er uit kan zien</string>
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
     
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -181,6 +181,6 @@ Para mais informação selecione <b>Info</b> do menu da aplicação.</string>
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">Ver um exemplo</string>
     <string name="preference_history_example_summary">Veja como o histórico deverá aparecer</string>   
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
     
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -181,6 +181,6 @@ Wi-Fi Matic автоматически активирует и деактиви�
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">Смотреть пример</string>
     <string name="preference_history_example_summary">Посмотрите, как будет выглядеть вкладка История</string>   
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
     
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,6 @@ For more information you can go to <b>Info</b> from the application menu.</strin
     <string name="market_billing_donation_sku2">org.cprados.wificellmanager.donation</string>
     <string name="preference_history_example_title">See an example</string>
     <string name="preference_history_example_summary">See how the History tab would look like</string>   
-    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/#History</string> 
+    <string name="url_history_example">https://sites.google.com/site/wifimaticapp/home/configuration#History</string> 
     
 </resources>


### PR DESCRIPTION
Patch to update the URL of the section where history tab is explained, linked from "See an example" in the donations tab. Needs to be changed since the web page was splited in sections. 
Apply before Japanese strings pull request.